### PR TITLE
expand read-string input

### DIFF
--- a/counsel-surfraw.el
+++ b/counsel-surfraw.el
@@ -22,7 +22,10 @@
   "Search for something online, using the surfraw command."
   (interactive)
   (let ((search-for (read-string "Search for: " nil 'counsel-surfraw-search-history
-                                 (thing-at-point 'symbol))))
+                                 (if (use-region-p)
+                                     (buffer-substring-no-properties
+                                      (region-beginning) (region-end))
+                                   (thing-at-point 'symbol)))))
     (ivy-read (format "Search for `%s` with: " search-for)
               #'counsel-surfraw-elvi
               :require-match t


### PR DESCRIPTION
read-string now is not restricted to thing-at-point. First, it detects if the region is activated and uses it. This little modification was inspired by helm-surfraw.

See at: https://github.com/emacs-helm/helm/blob/cdd30525edda6766ddf0aad8b8f6ddcc9992a288/helm-net.el#L392-L395